### PR TITLE
Hadoop container

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/README.md
+++ b/dcompose-stack/radar-cp-hadoop-stack/README.md
@@ -1,22 +1,16 @@
 # RADAR-CNS with a HDFS connector
 
-In the Dockerfile 3 HDFS volumes and the name directory are mounted. Create those before running. Also create a docker `hadoop` network.
+In the Dockerfile, 2 redundant HDFS volumes and the name directory are mounted. The local paths for those volumes have to be created before the first run. Also, create a docker `hadoop` network.
 
 ```shell
 DATA_DIR=/usr/local/var/lib/docker
-mkdir -p "$DATA_DIR/hadoop-data1" "$DATA_DIR/hadoop-data2" "$DATA_DIR/hadoop-data3" "$DATA_DIR/hadoop-name"
+mkdir -p "$DATA_DIR/hadoop-data1" "$DATA_DIR/hadoop-data2" "$DATA_DIR/hadoop-name"
 docker network create hadoop
 ``` 
 
-Data can be extracted from this setup by running
-```shell
-# Directory to write output to
-OUTPUT_DIR=$PWD/output
-# HDFS filename to get
-HDFS_FILE=/abc/test.txt
-# HDFS command to run
-HDFS_COMMAND="hdfs dfs -get $HDFS_FILE /home/output"
+Data can be extracted from this setup by running:
 
-mkdir -p $OUTPUT_DIR
-docker run --rm --network hadoop -v "$OUTPUT_DIR:/home/output" -e CLUSTER_NAME=radar-cns -e CORE_CONF_fs_defaultFS=hdfs://namenode:8020 uhopper/hadoop $HDFS_COMMAND
+```shell
+./extract_from_hdfs <hdfs file> <destination directory>
 ```
+This command will not overwrite data in the destination directory.

--- a/dcompose-stack/radar-cp-hadoop-stack/README.md
+++ b/dcompose-stack/radar-cp-hadoop-stack/README.md
@@ -1,0 +1,8 @@
+# RADAR-CNS with a HDFS connector
+
+In the Dockerfile 3 HDFS volumes are mounted. Create those before running:
+```
+mkdir -p /usr/local/var/lib/docker/hadoop-data1
+mkdir -p /usr/local/var/lib/docker/hadoop-data2
+mkdir -p /usr/local/var/lib/docker/hadoop-data3
+``` 

--- a/dcompose-stack/radar-cp-hadoop-stack/README.md
+++ b/dcompose-stack/radar-cp-hadoop-stack/README.md
@@ -1,8 +1,22 @@
 # RADAR-CNS with a HDFS connector
 
-In the Dockerfile 3 HDFS volumes are mounted. Create those before running:
-```
-mkdir -p /usr/local/var/lib/docker/hadoop-data1
-mkdir -p /usr/local/var/lib/docker/hadoop-data2
-mkdir -p /usr/local/var/lib/docker/hadoop-data3
+In the Dockerfile 3 HDFS volumes and the name directory are mounted. Create those before running. Also create a docker `hadoop` network.
+
+```shell
+DATA_DIR=/usr/local/var/lib/docker
+mkdir -p "$DATA_DIR/hadoop-data1" "$DATA_DIR/hadoop-data2" "$DATA_DIR/hadoop-data3" "$DATA_DIR/hadoop-name"
+docker network create hadoop
 ``` 
+
+Data can be extracted from this setup by running
+```shell
+# Directory to write output to
+OUTPUT_DIR=$PWD/output
+# HDFS filename to get
+HDFS_FILE=/abc/test.txt
+# HDFS command to run
+HDFS_COMMAND="hdfs dfs -get $HDFS_FILE /home/output"
+
+mkdir -p $OUTPUT_DIR
+docker run --rm --network hadoop -v "$OUTPUT_DIR:/home/output" -e CLUSTER_NAME=radar-cns -e CORE_CONF_fs_defaultFS=hdfs://namenode:8020 uhopper/hadoop $HDFS_COMMAND
+```

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -1,13 +1,26 @@
 version: '2'
 
+networks:
+  hadoop:
+    external: true
+  zookeeper:
+    driver: bridge
+  api:
+    driver: bridge
+  kafka:
+    driver: bridge
+
 services:
 
+  #---------------------------------------------------------------------------#
+  # Zookeeper Cluster
+  #---------------------------------------------------------------------------#
   zookeeper-1:
     image: confluentinc/cp-zookeeper:3.1.1
     domainname: zookeeper
     container_name: zookeeper-1
     networks:
-      - kafka
+      - zookeeper
     environment:
       ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_CLIENT_PORT: 22181
@@ -25,6 +38,7 @@ services:
     container_name: kafka-1
     networks:
       - kafka
+      - zookeeper
     depends_on:
       - zookeeper-1
     environment:
@@ -38,6 +52,7 @@ services:
     container_name: kafka-2
     networks:
       - kafka
+      - zookeeper
     depends_on:
       - zookeeper-1
     environment:
@@ -51,6 +66,7 @@ services:
     container_name: kafka-3
     networks:
       - kafka
+      - zookeeper
     depends_on:
       - zookeeper-1
     environment:
@@ -67,6 +83,7 @@ services:
     domainname: kafka
     networks:
       - kafka
+      - zookeeper
     depends_on:
       - kafka-1
       - kafka-2
@@ -88,6 +105,7 @@ services:
     container_name: rest-proxy-1
     networks:
       - kafka
+      - zookeeper
     depends_on:
       - kafka-1
       - kafka-2
@@ -101,8 +119,41 @@ services:
       KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry-1:8081
       KAFKA_REST_HOST_NAME: rest-proxy-1
 
+
+  #---------------------------------------------------------------------------#
+  # RADAR Hot-Storage                                                         #
+  #---------------------------------------------------------------------------#
+  mongo:
+    image: mongo:3.2.10
+    ports:
+      - "27017:27017"
+
+  #---------------------------------------------------------------------------#
+  # RADAR REST API                                                            #
+  #---------------------------------------------------------------------------#
+  tomcat:
+    image: tomcat:8.0.37
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+
+  #---------------------------------------------------------------------------#
+  # RADAR Dashboard                                                           #
+  #---------------------------------------------------------------------------#
+  nodejs:
+    image: node:7.0.0
+    ports:
+      - "80:8888"
+    depends_on:
+      - tomcat
+
+
+  #---------------------------------------------------------------------------#
+  # RADAR Cold Storage                                                        #
+  #---------------------------------------------------------------------------#
   datanode-1:
-    image: uhopper/hadoop-datanode
+    image: uhopper/hadoop-datanode:2.7.2
     domainname: hadoop
     networks:
       - hadoop
@@ -112,7 +163,7 @@ services:
       - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
       - HDFS_CONF_dfs_replication=2
   datanode-2:
-    image: uhopper/hadoop-datanode
+    image: uhopper/hadoop-datanode:2.7.2
     domainname: hadoop
     networks:
       - hadoop
@@ -122,7 +173,7 @@ services:
       - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
       - HDFS_CONF_dfs_replication=2
   namenode:
-    image: uhopper/hadoop-namenode
+    image: uhopper/hadoop-namenode:2.7.2
     hostname: namenode
     container_name: namenode
     domainname: hadoop
@@ -133,10 +184,3 @@ services:
     environment:
       - CLUSTER_NAME=radar-cns
 
-networks:
-  hadoop:
-    external: true
-  zookeeper:
-    driver: bridge
-  kafka:
-    driver: bridge

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -1,0 +1,37 @@
+datanode1:
+  image: uhopper/hadoop-datanode
+  domainname: hadoop
+  net: hadoop
+  volumes:
+    - /usr/local/var/lib/docker/hadoop-data1:/hadoop/dfs/data
+  environment:
+    - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+    - HDFS_CONF_dfs_replication=3
+datanode2:
+  image: uhopper/hadoop-datanode
+  domainname: hadoop
+  net: hadoop
+  volumes:
+    - /usr/local/var/lib/docker/hadoop-data2:/hadoop/dfs/data
+  environment:
+    - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+    - HDFS_CONF_dfs_replication=3
+datanode3:
+  image: uhopper/hadoop-datanode
+  domainname: hadoop
+  net: hadoop
+  volumes:
+    - /usr/local/var/lib/docker/hadoop-data3:/hadoop/dfs/data
+  environment:
+    - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+    - HDFS_CONF_dfs_replication=3
+namenode:
+  image: uhopper/hadoop-namenode
+  hostname: namenode
+  container_name: namenode
+  domainname: hadoop
+  net: hadoop
+  volumes:
+    - /usr/local/var/lib/docker/hadoop-name:/hadoop/dfs/name
+  environment:
+    - CLUSTER_NAME=radar-cns

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -1,7 +1,107 @@
 version: '2'
 
 services:
-  datanode1:
+
+  zookeeper-1:
+    image: confluentinc/cp-zookeeper:3.1.1
+    domainname: zookeeper
+    container_name: zookeeper-1
+    networks:
+      - kafka
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 22181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+      ZOOKEEPER_SERVERS: zookeeper-1:22888:23888
+
+  #---------------------------------------------------------------------------#
+  # Kafka Cluster                                                             #
+  #---------------------------------------------------------------------------#
+  kafka-1:
+    image: confluentinc/cp-kafka:3.1.1
+    domainname: kafka
+    container_name: kafka-1
+    networks:
+      - kafka
+    depends_on:
+      - zookeeper-1
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:19092
+
+  kafka-2:
+    image: confluentinc/cp-kafka:3.1.1
+    domainname: kafka
+    container_name: kafka-2
+    networks:
+      - kafka
+    depends_on:
+      - zookeeper-1
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:19092
+
+  kafka-3:
+    image: confluentinc/cp-kafka:3.1.1
+    domainname: kafka
+    container_name: kafka-3
+    networks:
+      - kafka
+    depends_on:
+      - zookeeper-1
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:19092
+
+  #---------------------------------------------------------------------------#
+  # Schema Registry                                                           #
+  #---------------------------------------------------------------------------#
+  schema-registry-1:
+    image: confluentinc/cp-schema-registry:3.1.1
+    container_name: schema-registry-1
+    domainname: kafka
+    networks:
+      - kafka
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper-1:22181
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry-1
+      SCHEMA_REGISTRY_LISTENERS: http://schema-registry-1:8081
+
+  #---------------------------------------------------------------------------#
+  # REST proxy                                                                #
+  #---------------------------------------------------------------------------#
+  rest-proxy-1:
+    image: confluentinc/cp-kafka-rest:3.1.1
+    domainname: kafka
+    container_name: rest-proxy-1
+    networks:
+      - kafka
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3
+      - schema-registry-1
+    ports:
+      - "8082:8082"
+    environment:
+      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper-1:22181
+      KAFKA_REST_LISTENERS: http://rest-proxy-1:8082
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry-1:8081
+      KAFKA_REST_HOST_NAME: rest-proxy-1
+
+  datanode-1:
     image: uhopper/hadoop-datanode
     domainname: hadoop
     networks:
@@ -11,7 +111,7 @@ services:
     environment:
       - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
       - HDFS_CONF_dfs_replication=2
-  datanode2:
+  datanode-2:
     image: uhopper/hadoop-datanode
     domainname: hadoop
     networks:
@@ -36,3 +136,7 @@ services:
 networks:
   hadoop:
     external: true
+  zookeeper:
+    driver: bridge
+  kafka:
+    driver: bridge

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -1,41 +1,38 @@
+---
 version: '2'
 
 networks:
-  hadoop:
-    external: true
   zookeeper:
-    driver: bridge
-  api:
     driver: bridge
   kafka:
     driver: bridge
+  api:
+    driver: bridge
+  hadoop:
+    external: true
 
 services:
 
   #---------------------------------------------------------------------------#
-  # Zookeeper Cluster
+  # Zookeeper Cluster                                                         #
   #---------------------------------------------------------------------------#
   zookeeper-1:
     image: confluentinc/cp-zookeeper:3.1.1
-    domainname: zookeeper
-    container_name: zookeeper-1
     networks:
       - zookeeper
     environment:
       ZOOKEEPER_SERVER_ID: 1
-      ZOOKEEPER_CLIENT_PORT: 22181
+      ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
       ZOOKEEPER_INIT_LIMIT: 5
       ZOOKEEPER_SYNC_LIMIT: 2
-      ZOOKEEPER_SERVERS: zookeeper-1:22888:23888
+      ZOOKEEPER_SERVERS: zookeeper-1:2888:3888
 
   #---------------------------------------------------------------------------#
   # Kafka Cluster                                                             #
   #---------------------------------------------------------------------------#
   kafka-1:
     image: confluentinc/cp-kafka:3.1.1
-    domainname: kafka
-    container_name: kafka-1
     networks:
       - kafka
       - zookeeper
@@ -43,44 +40,38 @@ services:
       - zookeeper-1
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:19092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:9092
 
   kafka-2:
     image: confluentinc/cp-kafka:3.1.1
-    domainname: kafka
-    container_name: kafka-2
     networks:
       - kafka
       - zookeeper
     depends_on:
-      - zookeeper-1
+      - kafka-1
     environment:
       KAFKA_BROKER_ID: 2
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:19092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:9092
 
   kafka-3:
     image: confluentinc/cp-kafka:3.1.1
-    domainname: kafka
-    container_name: kafka-3
     networks:
       - kafka
       - zookeeper
     depends_on:
-      - zookeeper-1
+      - kafka-2
     environment:
       KAFKA_BROKER_ID: 3
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:19092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:9092
 
   #---------------------------------------------------------------------------#
   # Schema Registry                                                           #
   #---------------------------------------------------------------------------#
   schema-registry-1:
     image: confluentinc/cp-schema-registry:3.1.1
-    container_name: schema-registry-1
-    domainname: kafka
     networks:
       - kafka
       - zookeeper
@@ -92,7 +83,7 @@ services:
     ports:
       - "8081:8081"
     environment:
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper-1:22181
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper-1:2181
       SCHEMA_REGISTRY_HOST_NAME: schema-registry-1
       SCHEMA_REGISTRY_LISTENERS: http://schema-registry-1:8081
 
@@ -101,8 +92,6 @@ services:
   #---------------------------------------------------------------------------#
   rest-proxy-1:
     image: confluentinc/cp-kafka-rest:3.1.1
-    domainname: kafka
-    container_name: rest-proxy-1
     networks:
       - kafka
       - zookeeper
@@ -114,17 +103,19 @@ services:
     ports:
       - "8082:8082"
     environment:
-      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper-1:22181
+      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper-1:2181
       KAFKA_REST_LISTENERS: http://rest-proxy-1:8082
       KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry-1:8081
       KAFKA_REST_HOST_NAME: rest-proxy-1
 
 
   #---------------------------------------------------------------------------#
-  # RADAR Hot-Storage                                                         #
+  # RADAR Hot Storage                                                         #
   #---------------------------------------------------------------------------#
   mongo:
     image: mongo:3.2.10
+    networks:
+      - api
     ports:
       - "27017:27017"
 
@@ -133,6 +124,8 @@ services:
   #---------------------------------------------------------------------------#
   tomcat:
     image: tomcat:8.0.37
+    networks:
+      - api
     ports:
       - "8080:8080"
     depends_on:
@@ -143,6 +136,8 @@ services:
   #---------------------------------------------------------------------------#
   nodejs:
     image: node:7.0.0
+    networks:
+      - api
     ports:
       - "80:8888"
     depends_on:

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '2'
+
 services:
   datanode1:
     image: uhopper/hadoop-datanode
@@ -9,7 +10,7 @@ services:
       - /usr/local/var/lib/docker/hadoop-data1:/hadoop/dfs/data
     environment:
       - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
-      - HDFS_CONF_dfs_replication=3
+      - HDFS_CONF_dfs_replication=2
   datanode2:
     image: uhopper/hadoop-datanode
     domainname: hadoop
@@ -19,17 +20,7 @@ services:
       - /usr/local/var/lib/docker/hadoop-data2:/hadoop/dfs/data
     environment:
       - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
-      - HDFS_CONF_dfs_replication=3
-  datanode3:
-    image: uhopper/hadoop-datanode
-    domainname: hadoop
-    networks:
-      - hadoop
-    volumes:
-      - /usr/local/var/lib/docker/hadoop-data3:/hadoop/dfs/data
-    environment:
-      - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
-      - HDFS_CONF_dfs_replication=3
+      - HDFS_CONF_dfs_replication=2
   namenode:
     image: uhopper/hadoop-namenode
     hostname: namenode
@@ -41,6 +32,7 @@ services:
       - /usr/local/var/lib/docker/hadoop-name:/hadoop/dfs/name
     environment:
       - CLUSTER_NAME=radar-cns
+
 networks:
   hadoop:
     external: true

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -1,37 +1,46 @@
-datanode1:
-  image: uhopper/hadoop-datanode
-  domainname: hadoop
-  net: hadoop
-  volumes:
-    - /usr/local/var/lib/docker/hadoop-data1:/hadoop/dfs/data
-  environment:
-    - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
-    - HDFS_CONF_dfs_replication=3
-datanode2:
-  image: uhopper/hadoop-datanode
-  domainname: hadoop
-  net: hadoop
-  volumes:
-    - /usr/local/var/lib/docker/hadoop-data2:/hadoop/dfs/data
-  environment:
-    - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
-    - HDFS_CONF_dfs_replication=3
-datanode3:
-  image: uhopper/hadoop-datanode
-  domainname: hadoop
-  net: hadoop
-  volumes:
-    - /usr/local/var/lib/docker/hadoop-data3:/hadoop/dfs/data
-  environment:
-    - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
-    - HDFS_CONF_dfs_replication=3
-namenode:
-  image: uhopper/hadoop-namenode
-  hostname: namenode
-  container_name: namenode
-  domainname: hadoop
-  net: hadoop
-  volumes:
-    - /usr/local/var/lib/docker/hadoop-name:/hadoop/dfs/name
-  environment:
-    - CLUSTER_NAME=radar-cns
+version: '2'
+services:
+  datanode1:
+    image: uhopper/hadoop-datanode
+    domainname: hadoop
+    networks:
+      - hadoop
+    volumes:
+      - /usr/local/var/lib/docker/hadoop-data1:/hadoop/dfs/data
+    environment:
+      - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+      - HDFS_CONF_dfs_replication=3
+  datanode2:
+    image: uhopper/hadoop-datanode
+    domainname: hadoop
+    networks:
+      - hadoop
+    volumes:
+      - /usr/local/var/lib/docker/hadoop-data2:/hadoop/dfs/data
+    environment:
+      - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+      - HDFS_CONF_dfs_replication=3
+  datanode3:
+    image: uhopper/hadoop-datanode
+    domainname: hadoop
+    networks:
+      - hadoop
+    volumes:
+      - /usr/local/var/lib/docker/hadoop-data3:/hadoop/dfs/data
+    environment:
+      - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+      - HDFS_CONF_dfs_replication=3
+  namenode:
+    image: uhopper/hadoop-namenode
+    hostname: namenode
+    container_name: namenode
+    domainname: hadoop
+    networks:
+      - hadoop
+    volumes:
+      - /usr/local/var/lib/docker/hadoop-name:/hadoop/dfs/name
+    environment:
+      - CLUSTER_NAME=radar-cns
+networks:
+  hadoop:
+    external: true

--- a/dcompose-stack/radar-cp-hadoop-stack/extract_from_hdfs.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/extract_from_hdfs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [[ $# -lt 1 || $1 = "-h" || $1 = "--help" ]]; then
+   printf "Usage:\n$0 <hdfs path> [<destination directory>]\nThe destination directory defaults to ./output\n"
+   exit 1
+fi
+
+# HDFS filename to get
+HDFS_FILE=$1
+# Directory to write output to
+OUTPUT_DIR=${2:-$PWD/output}
+# Internal docker directory to write output to
+HDFS_OUTPUT_DIR=/home/output
+# HDFS command to run
+HDFS_COMMAND="hdfs dfs -get $HDFS_FILE $HDFS_OUTPUT_DIR"
+
+mkdir -p $OUTPUT_DIR
+docker run --rm --network hadoop -v "$OUTPUT_DIR:$HDFS_OUTPUT_DIR" -e CLUSTER_NAME=radar-cns -e CORE_CONF_fs_defaultFS=hdfs://namenode:8020 uhopper/hadoop $HDFS_COMMAND

--- a/dcompose-stack/radar-cp-hadoop-stack/extract_from_hdfs.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/extract_from_hdfs.sh
@@ -15,4 +15,4 @@ HDFS_OUTPUT_DIR=/home/output
 HDFS_COMMAND="hdfs dfs -get $HDFS_FILE $HDFS_OUTPUT_DIR"
 
 mkdir -p $OUTPUT_DIR
-docker run --rm --network hadoop -v "$OUTPUT_DIR:$HDFS_OUTPUT_DIR" -e CLUSTER_NAME=radar-cns -e CORE_CONF_fs_defaultFS=hdfs://namenode:8020 uhopper/hadoop $HDFS_COMMAND
+docker run --rm --network hadoop -v "$OUTPUT_DIR:$HDFS_OUTPUT_DIR" -e CLUSTER_NAME=radar-cns -e CORE_CONF_fs_defaultFS=hdfs://namenode:8020 uhopper/hadoop:2.7.2 $HDFS_COMMAND

--- a/dcompose-stack/radar-cp-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-stack/docker-compose.yml
@@ -86,9 +86,9 @@ services:
     image: confluentinc/cp-schema-registry:3.1.1
     network_mode: host
     depends_on:
-      - "zookeeper-1"
-      - "zookeeper-2"
-      - "zookeeper-3"
+      - "kafka-1"
+      - "kafka-2"
+      - "kafka-3"
     restart: always
     ports:
       - "8081:8081"

--- a/dcompose-stack/radar-cp-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-stack/docker-compose.yml
@@ -39,7 +39,6 @@ services:
       ZOOKEEPER_SERVERS: localhost:22888:23888;localhost:32888:33888;localhost:42888:43888
     network_mode: host
 
-
   #---------------------------------------------------------------------------#
   # Kafka Cluster                                                             #
   #---------------------------------------------------------------------------#
@@ -59,9 +58,7 @@ services:
     image: confluentinc/cp-kafka:3.1.1
     network_mode: host
     depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
+      - kafka-1
     environment:
       KAFKA_BROKER_ID: 2
       KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
@@ -71,9 +68,7 @@ services:
     image: confluentinc/cp-kafka:3.1.1
     network_mode: host
     depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
+      - kafka-2
     environment:
       KAFKA_BROKER_ID: 3
       KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
@@ -86,50 +81,49 @@ services:
     image: confluentinc/cp-schema-registry:3.1.1
     network_mode: host
     depends_on:
-      - "kafka-1"
-      - "kafka-2"
-      - "kafka-3"
+      - kafka-1
+      - kafka-2
+      - kafka-3
     restart: always
     ports:
       - "8081:8081"
     environment:
       #SR_KAFKASTORE_CONNECTION_URL: "zookeeper-sasl-1:2181"
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: "localhost:32181"
-      SCHEMA_REGISTRY_HOST_NAME: "localhost"
-      SCHEMA_REGISTRY_LISTENERS: "http://localhost:8081"
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: localhost:32181
+      SCHEMA_REGISTRY_HOST_NAME: localhost
+      SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
 
   #---------------------------------------------------------------------------#
   # Kafka Connector                                                           #
   #---------------------------------------------------------------------------#
-  connect:
-    image: confluentinc/cp-kafka-connect:3.1.1
-    network_mode: host
-    depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
-      - kafka-1
-      - kafka-2
-      - kafka-3
-      - schema-registry-1
-    ports:
-      - "8083:8083"
-    environment:
-      CONNECT_BOOTSTRAP_SERVERS: 'localhost:19092'
-      CONNECT_REST_ADVERTISED_HOST_NAME: connect
-      CONNECT_REST_PORT: 8083
-      CONNECT_GROUP_ID: compose-connect-group
-      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
-      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
-      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
-      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
-      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
-      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-      CONNECT_ZOOKEEPER_CONNECT: 'zookeeper-1:2181'  
-
+#  connect:
+#    image: confluentinc/cp-kafka-connect:3.1.1
+#    network_mode: host
+#    depends_on:
+#      - zookeeper-1
+#      - zookeeper-2
+#      - zookeeper-3
+#      - kafka-1
+#      - kafka-2
+#      - kafka-3
+#      - schema-registry-1
+#    ports:
+#      - "8083:8083"
+#    environment:
+#      CONNECT_BOOTSTRAP_SERVERS: localhost:19092,localhost:29092,localhost:39092
+#      CONNECT_REST_ADVERTISED_HOST_NAME: connect
+#      CONNECT_REST_PORT: 8083
+#      CONNECT_GROUP_ID: compose-connect-group
+#      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+#      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+#      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+#      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
+#      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+#      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+#      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+#      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+#      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+#      CONNECT_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181 
 
   #---------------------------------------------------------------------------#
   # REST proxy                                                                #
@@ -138,40 +132,37 @@ services:
     image: confluentinc/cp-kafka-rest:3.1.1
     network_mode: host
     depends_on:
-      - "kafka-1"
-      - "kafka-2"
-      - "kafka-3"
-      - "schema-registry-1"
+      - kafka-1
+      - kafka-2
+      - kafka-3
+      - schema-registry-1
     ports:
       - "8082:8082"
     environment:
       #RP_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       #RP_ZOOKEEPER_CONNECT: "zookeeper-sasl-1:2181"
-      KAFKA_REST_ZOOKEEPER_CONNECT: "localhost:32181"
-      KAFKA_REST_LISTENERS: "http://localhost:8082"
-      KAFKA_REST_SCHEMA_REGISTRY_URL: "http://localhost:8081"
-      KAFKA_REST_HOST_NAME: "localhost"
-
-
-
+      KAFKA_REST_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
+      KAFKA_REST_LISTENERS: http://localhost:8082
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://localhost:8081
+      KAFKA_REST_HOST_NAME: localhost
 
   #---------------------------------------------------------------------------#
   # RADRA Storage                                                             #
   #---------------------------------------------------------------------------#
-  mongo:
-    image: mongo:3.2.10
-    ports:
-      - "27017:27017"
+#  mongo:
+#    image: mongo:3.2.10
+#    ports:
+#      - "27017:27017"
 
   #---------------------------------------------------------------------------#
   # RADAR REST API                                                            #
   #---------------------------------------------------------------------------#
-  tomcat:
-    image: tomcat:8.0.37
-    ports:
-      - "8080:8080"
-    depends_on:
-      - mongo
+#  tomcat:
+#    image: tomcat:8.0.37
+#    ports:
+#      - "8080:8080"
+#    depends_on:
+#      - mongo
 
   #---------------------------------------------------------------------------#
   # RADRA Dashboard                                                           #
@@ -182,7 +173,3 @@ services:
 #      - "80:8888"
 #    depends_on:
 #      - tomcat
-
-
-
-

--- a/dcompose-stack/radar-cp-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-stack/docker-compose.yml
@@ -80,11 +80,6 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:39092
 
   #---------------------------------------------------------------------------#
-  # Kafka Connector                                                           #
-  #---------------------------------------------------------------------------#
-  
-
-  #---------------------------------------------------------------------------#
   # Schema Registry                                                           #
   #---------------------------------------------------------------------------#
   schema-registry-1:
@@ -102,6 +97,39 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: "localhost:32181"
       SCHEMA_REGISTRY_HOST_NAME: "localhost"
       SCHEMA_REGISTRY_LISTENERS: "http://localhost:8081"
+
+  #---------------------------------------------------------------------------#
+  # Kafka Connector                                                           #
+  #---------------------------------------------------------------------------#
+  connect:
+    image: confluentinc/cp-kafka-connect:3.1.1
+    network_mode: host
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+      - kafka-1
+      - kafka-2
+      - kafka-3
+      - schema-registry-1
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: 'localhost:19092'
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: compose-connect-group
+      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_ZOOKEEPER_CONNECT: 'zookeeper-1:2181'  
+
 
   #---------------------------------------------------------------------------#
   # REST proxy                                                                #

--- a/dcompose-stack/radar-cp-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-stack/docker-compose.yml
@@ -1,85 +1,104 @@
 ---
 version: '2'
+
+networks:
+  zookeeper:
+    driver: bridge
+  kafka:
+    driver: bridge
+  api:
+    driver: bridge
+
 services:
 
   #---------------------------------------------------------------------------#
   # Zookeeper Cluster                                                         #
-  # *NB Zookeeper clust should prob go on separate network                    #
   #---------------------------------------------------------------------------#
   zookeeper-1:
     image: confluentinc/cp-zookeeper:3.1.1
+    networks:
+      - zookeeper
     environment:
       ZOOKEEPER_SERVER_ID: 1
-      ZOOKEEPER_CLIENT_PORT: 22181
+      ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
       ZOOKEEPER_INIT_LIMIT: 5
       ZOOKEEPER_SYNC_LIMIT: 2
-      ZOOKEEPER_SERVERS: localhost:22888:23888;localhost:32888:33888;localhost:42888:43888
-    network_mode: host
+      ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-2:
     image: confluentinc/cp-zookeeper:3.1.1
+    networks:
+      - zookeeper
     environment:
       ZOOKEEPER_SERVER_ID: 2
-      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
       ZOOKEEPER_INIT_LIMIT: 5
       ZOOKEEPER_SYNC_LIMIT: 2
-      ZOOKEEPER_SERVERS: localhost:22888:23888;localhost:32888:33888;localhost:42888:43888
-    network_mode: host
+      ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-3:
     image: confluentinc/cp-zookeeper:3.1.1
+    networks:
+      - zookeeper
     environment:
       ZOOKEEPER_SERVER_ID: 3
-      ZOOKEEPER_CLIENT_PORT: 42181
+      ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
       ZOOKEEPER_INIT_LIMIT: 5
       ZOOKEEPER_SYNC_LIMIT: 2
-      ZOOKEEPER_SERVERS: localhost:22888:23888;localhost:32888:33888;localhost:42888:43888
-    network_mode: host
+      ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   #---------------------------------------------------------------------------#
   # Kafka Cluster                                                             #
   #---------------------------------------------------------------------------#
   kafka-1:
     image: confluentinc/cp-kafka:3.1.1
-    network_mode: host
+    networks:
+      - kafka
+      - zookeeper
     depends_on:
       - zookeeper-1
       - zookeeper-2
       - zookeeper-3
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:19092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:9092
 
   kafka-2:
     image: confluentinc/cp-kafka:3.1.1
-    network_mode: host
+    networks:
+      - kafka
+      - zookeeper
     depends_on:
       - kafka-1
     environment:
       KAFKA_BROKER_ID: 2
-      KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:9092
 
   kafka-3:
     image: confluentinc/cp-kafka:3.1.1
-    network_mode: host
+    networks:
+      - kafka
+      - zookeeper
     depends_on:
       - kafka-2
     environment:
       KAFKA_BROKER_ID: 3
-      KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:39092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:9092
 
   #---------------------------------------------------------------------------#
   # Schema Registry                                                           #
   #---------------------------------------------------------------------------#
   schema-registry-1:
     image: confluentinc/cp-schema-registry:3.1.1
-    network_mode: host
+    networks:
+      - kafka
+      - zookeeper
     depends_on:
       - kafka-1
       - kafka-2
@@ -88,17 +107,18 @@ services:
     ports:
       - "8081:8081"
     environment:
-      #SR_KAFKASTORE_CONNECTION_URL: "zookeeper-sasl-1:2181"
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: localhost:32181
-      SCHEMA_REGISTRY_HOST_NAME: localhost
-      SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper-1:2181
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry-1
+      SCHEMA_REGISTRY_LISTENERS: http://schema-registry-1:8081
 
   #---------------------------------------------------------------------------#
   # Kafka Connector                                                           #
   #---------------------------------------------------------------------------#
   connect:
     image: confluentinc/cp-kafka-connect:3.1.1
-    network_mode: host
+    networks:
+      - kafka
+      - zookeeper
     depends_on:
       - zookeeper-1
       - zookeeper-2
@@ -110,7 +130,7 @@ services:
     ports:
       - "8083:8083"
     environment:
-      CONNECT_BOOTSTRAP_SERVERS: localhost:19092,localhost:29092,localhost:39092
+      CONNECT_BOOTSTRAP_SERVERS: kafka-1:9092,kafka-2:9092,kafka-3:9092
       CONNECT_REST_ADVERTISED_HOST_NAME: connect
       CONNECT_REST_PORT: 8083
       CONNECT_GROUP_ID: compose-connect-group
@@ -118,19 +138,21 @@ services:
       CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
       CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
       CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema-registry-1:8081'
       CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema-registry-1:8081'
       CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-      CONNECT_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181 
+      CONNECT_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 
 
   #---------------------------------------------------------------------------#
   # REST proxy                                                                #
   #---------------------------------------------------------------------------#
   rest-proxy-1:
     image: confluentinc/cp-kafka-rest:3.1.1
-    network_mode: host
+    networks:
+      - kafka
+      - zookeeper
     depends_on:
       - kafka-1
       - kafka-2
@@ -139,18 +161,19 @@ services:
     ports:
       - "8082:8082"
     environment:
-      #RP_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
-      #RP_ZOOKEEPER_CONNECT: "zookeeper-sasl-1:2181"
-      KAFKA_REST_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
-      KAFKA_REST_LISTENERS: http://localhost:8082
-      KAFKA_REST_SCHEMA_REGISTRY_URL: http://localhost:8081
-      KAFKA_REST_HOST_NAME: localhost
+      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      KAFKA_REST_LISTENERS: http://rest-proxy-1:8082
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry-1:8081
+      KAFKA_REST_HOST_NAME: rest-proxy-1
+
 
   #---------------------------------------------------------------------------#
-  # RADRA Storage                                                             #
+  # RADAR Hot Storage                                                         #
   #---------------------------------------------------------------------------#
 #  mongo:
 #    image: mongo:3.2.10
+#    networks:
+#      - api
 #    ports:
 #      - "27017:27017"
 
@@ -159,16 +182,20 @@ services:
   #---------------------------------------------------------------------------#
 #  tomcat:
 #    image: tomcat:8.0.37
+#    networks:
+#      - api
 #    ports:
 #      - "8080:8080"
 #    depends_on:
 #      - mongo
 
   #---------------------------------------------------------------------------#
-  # RADRA Dashboard                                                           #
+  # RADAR Dashboard                                                           #
   #---------------------------------------------------------------------------#
 #  nodejs:
 #    image: node:7.0.0
+#    networks:
+#      - api
 #    ports:
 #      - "80:8888"
 #    depends_on:

--- a/dcompose-stack/radar-cp-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-stack/docker-compose.yml
@@ -96,34 +96,34 @@ services:
   #---------------------------------------------------------------------------#
   # Kafka Connector                                                           #
   #---------------------------------------------------------------------------#
-#  connect:
-#    image: confluentinc/cp-kafka-connect:3.1.1
-#    network_mode: host
-#    depends_on:
-#      - zookeeper-1
-#      - zookeeper-2
-#      - zookeeper-3
-#      - kafka-1
-#      - kafka-2
-#      - kafka-3
-#      - schema-registry-1
-#    ports:
-#      - "8083:8083"
-#    environment:
-#      CONNECT_BOOTSTRAP_SERVERS: localhost:19092,localhost:29092,localhost:39092
-#      CONNECT_REST_ADVERTISED_HOST_NAME: connect
-#      CONNECT_REST_PORT: 8083
-#      CONNECT_GROUP_ID: compose-connect-group
-#      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
-#      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
-#      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
-#      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-#      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
-#      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-#      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
-#      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-#      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-#      CONNECT_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181 
+  connect:
+    image: confluentinc/cp-kafka-connect:3.1.1
+    network_mode: host
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+      - kafka-1
+      - kafka-2
+      - kafka-3
+      - schema-registry-1
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: localhost:19092,localhost:29092,localhost:39092
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: compose-connect-group
+      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://localhost:8081'
+      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181 
 
   #---------------------------------------------------------------------------#
   # REST proxy                                                                #


### PR DESCRIPTION
Added a hadoop container, including functionality to extract data, in the `dcompose-stack/radar-cp-hadoop-stack/` directory.

I also found out how to run the Confluent docker containers without using `--net=host`, see `dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml`. This means the setup also runs on Mac and that it does not open any unneeded ports on the host.