### PR TITLE
Support for multiple name node directories.

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/README.md
+++ b/dcompose-stack/radar-cp-hadoop-stack/README.md
@@ -14,9 +14,12 @@ For a redundant data storage, instead of the directories created in `$DOCKER_DAT
 DOCKER_DATA=/usr/local/var/lib/docker
 VOLUME_1=/volume1
 VOLUME_2=/volume1
-mkdir -p $VOLUME_1/hdfs-data $VOLUME_2/hdfs-data
-ln -s $VOLUME_1/hdfs-data $DOCKER_DATA/hdfs-data1
-ln -s $VOLUME_2/hdfs-data $DOCKER_DATA/hdfs-data2
+mkdir -p "$VOLUME_1/hdfs-data" "$VOLUME_1/hdfs-name"
+mkdir -p "$VOLUME_2/hdfs-data" "$VOLUME_2/hdfs-name"
+ln -s "$VOLUME_1/hdfs-data" "$DOCKER_DATA/hdfs-data1"
+ln -s "$VOLUME_2/hdfs-data" "$DOCKER_DATA/hdfs-data2"
+ln -s "$VOLUME_1/hdfs-name" "$DOCKER_DATA/hdfs-name1"
+ln -s "$VOLUME_2/hdfs-name" "$DOCKER_DATA/hdfs-name2"
 ```
 
 Modify `mail.env.template` to set a SMTP host to send emails with, and move it to `mail.env`. The configuration settings are passed to a [namshi/smtp](https://hub.docker.com/r/namshi/smtp/) Docker container.

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -170,13 +170,16 @@ services:
       HDFS_CONF_dfs_replication: 2
 
   hdfs-namenode:
-    image: uhopper/hadoop-namenode:2.7.2
+    build: hdfs-namenode
+    image: radarcns/hdfs-namenode:2.7.2
     networks:
       - hadoop
     volumes:
-      - /usr/local/var/lib/docker/hdfs-name:/hadoop/dfs/name
+      - /usr/local/var/lib/docker/hdfs-name1:/hadoop/dfs/name/1
+      - /usr/local/var/lib/docker/hdfs-name2:/hadoop/dfs/name/2
     environment:
       CLUSTER_NAME: radar-cns
+      HDFS_CONF_dfs_namenode_name_dir: file:///hadoop/dfs/name/1,file:///hadoop/dfs/name/2
 
   #---------------------------------------------------------------------------#
   # Email server                                                              #

--- a/dcompose-stack/radar-cp-hadoop-stack/hdfs-namenode/Dockerfile
+++ b/dcompose-stack/radar-cp-hadoop-stack/hdfs-namenode/Dockerfile
@@ -1,0 +1,4 @@
+FROM uhopper/hadoop-namenode:2.7.2
+
+ADD run.sh /run.sh
+RUN chmod a+x /run.sh

--- a/dcompose-stack/radar-cp-hadoop-stack/hdfs-namenode/run.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/hdfs-namenode/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -z "$CLUSTER_NAME" ]; then
+  echo "Cluster name not specified"
+  exit 2
+fi
+
+IFS=',' read -r -a namedirs <<< $(echo "$HDFS_CONF_dfs_namenode_name_dir" | sed -e 's#file://##g')
+
+for namedir in "${namedirs[@]}"; do
+  mkdir -p "$namedir"
+  if [ ! -d "$namedir" ]; then
+    echo "Namenode name directory not found: $namedir"
+    exit 2
+  fi
+  
+  if [ -z "$(ls -A "$namedir")" ]; then
+    echo "Formatting namenode name directory: $namedir is not yet formatted"
+    $HADOOP_PREFIX/bin/hdfs --config $HADOOP_CONF_DIR namenode -format $CLUSTER_NAME 
+    break
+  fi
+done
+
+$HADOOP_PREFIX/bin/hdfs --config $HADOOP_CONF_DIR namenode


### PR DESCRIPTION
This way, the name node stores the directory information (+- like filesystem inodes) in duplicate. By mounting the name directory on different volumes, some redundancy in data can be achieved.

The run script is based on the run script of [uhopper/hadoop-namenode](https://bitbucket.org/uhopper/hadoop-docker/src/bf2f18501802/namenode/?at=master), except that it supports multiple name node directories.