### PR TITLE
Use WSO2 v5.3.0 and remove mysql

### DIFF
--- a/dcompose-stack/radar-security-only-stack/.env
+++ b/dcompose-stack/radar-security-only-stack/.env
@@ -1,5 +1,5 @@
 MONGODB_DIR=/usr/local/var/lib/docker/mongodb
-HOTSTORAGE_USERNAME=mongodb-user
-HOTSTORAGE_PASSWORD=mongodb-pw
-HOTSTORAGE_NAME=mongodb-database
+HOTSTORAGE_USERNAME=<mongodb-user>
+HOTSTORAGE_PASSWORD=<mongodb-password>
+HOTSTORAGE_NAME=<mongodb-database>
 IS_VERSION=5.3.0

--- a/dcompose-stack/radar-security-only-stack/.env
+++ b/dcompose-stack/radar-security-only-stack/.env
@@ -1,4 +1,5 @@
 MONGODB_DIR=/usr/local/var/lib/docker/mongodb
-HOTSTORAGE_USERNAME=<username>
-HOTSTORAGE_PASSWORD=<password>
-HOTSTORAGE_NAME=<database-name>
+HOTSTORAGE_USERNAME=mongodb-user
+HOTSTORAGE_PASSWORD=mongodb-pw
+HOTSTORAGE_NAME=mongodb-database
+IS_VERSION=5.3.0

--- a/dcompose-stack/radar-security-only-stack/docker-compose.yml
+++ b/dcompose-stack/radar-security-only-stack/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   # WSO2 Identity Server                                                      #
   #---------------------------------------------------------------------------#
   is:
-    image: isim/wso2is:5.0.0
+    image: isim/wso2is:$IS_VERSION
     networks:
       - api
     hostname: localhost

--- a/dcompose-stack/radar-security-only-stack/wso2is/carbon.xml
+++ b/dcompose-stack/radar-security-only-stack/wso2is/carbon.xml
@@ -45,12 +45,12 @@
        This is will become part of the End Point Reference of the
        services deployed on this server instance.
     -->
-    <HostName>wso2identity</HostName>
+    <HostName>localhost</HostName>
 
     <!--
     Host name to be used for the Carbon management console
     -->
-    <MgtHostName>wso2identity</MgtHostName>
+    <MgtHostName>localhost</MgtHostName>
 
     <!--
         The URL of the back end server. This is where the admin services are hosted and

--- a/dcompose-stack/radar-security-only-stack/wso2is/master-datasources.xml
+++ b/dcompose-stack/radar-security-only-stack/wso2is/master-datasources.xml
@@ -27,7 +27,7 @@
       </definition>
     </datasource>
 
-    <datasource>
+    <!--datasource>
       <name>WSO2_CARBON_DB_GREG</name>
       <description>The datasource used for registry and user manager</description>
       <jndiConfig>
@@ -46,9 +46,9 @@
           <validationInterval>30000</validationInterval>
         </configuration>
       </definition>
-    </datasource>
+    </datasource-->
 
-    <datasource>
+    <!--datasource>
       <name>WSO2_CARBON_DB_IDENTITY</name>
       <description>The datasource used for IAM</description>
       <jndiConfig>
@@ -67,7 +67,7 @@
           <validationInterval>30000</validationInterval>
         </configuration>
       </definition>
-    </datasource>
+    </datasource-->
 
     <!-- For an explanation of the properties, see: http://people.apache.org/~fhanik/jdbc-pool/jdbc-pool.html -->
     <!--datasource>

--- a/dcompose-stack/radar-security-only-stack/wso2is/registry.xml
+++ b/dcompose-stack/radar-security-only-stack/wso2is/registry.xml
@@ -76,14 +76,14 @@
       <dataSource>jdbc/WSO2CarbonDB_GREG</dataSource>
     </dbConfig>
 
-    <remoteInstance url="$GREG_REMOTE_URL">
+    <!--remoteInstance url="$GREG_REMOTE_URL">
       <id>instanceid</id>
       <dbConfig>remote_registry</dbConfig>
       <cacheId>root@jdbc:mysql://wso2_mysql_1:3306/registrydb</cacheId>
       <readOnly>false</readOnly>
       <enableCache>false</enableCache>
       <registryRoot>/</registryRoot>
-    </remoteInstance>
+    </remoteInstance-->
 
     <mount path="/_system/governance" overwrite="true">
       <instanceId>instanceid</instanceId>

--- a/dcompose-stack/radar-security-only-stack/wso2is/user-mgt.xml
+++ b/dcompose-stack/radar-security-only-stack/wso2is/user-mgt.xml
@@ -24,7 +24,7 @@
                      <Password>admin</Password>
                 </AdminUser>
             <EveryOneRoleName>everyone</EveryOneRoleName> <!-- By default users in this role sees the registry root -->
-            <Property name="dataSource">jdbc/WSO2CarbonDBIdentity</Property>
+            <Property name="dataSource">jdbc/WSO2CarbonDB</Property>
         </Configuration>
 	<!-- Following is the default user store manager. This user store manager is based on embedded-apacheds LDAP. It reads/writes users and roles into the 		     default apacheds LDAP user store. Descriptions about each of the following properties can be found in user management documentation of the 	 respective product. In case if user core cache domain is needed to identify uniquely set property <Property name="UserCoreCacheIdentifier">domain</Property>
 	     Note: Do not comment within UserStoreManager tags. Cause, specific tag names are used as tokens when building configurations for products. -->


### PR DESCRIPTION
Changed to WSO2IS version 5.3.0 (was 5.0.0)
Removed use of mysql database (now should use embedded LDAP)
Removed references to unused WSO2 packages