### PR TITLE
Kafka-shell for checking topics availability

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -312,7 +312,6 @@ services:
       CONNECT_CONSUMER_MAX_POLL_INTERVAL_MS: 300000
       CONNECT_CONSUMER_SESSION_TIMEOUT_MS: 10000
       CONNECT_CONSUMER_HEARTBEAT_INTERVAL_MS: 3000
-      KAFKA_REST_PROXY: http://rest-proxy-1:8082
       TOPIC_LIST: ${RADAR_TOPIC_LIST}
 
   #---------------------------------------------------------------------------#
@@ -355,7 +354,6 @@ services:
       CONNECT_OFFSET_STORAGE_FILE_FILENAME: "/tmp/connect2.offset"
       CONNECT_REST_ADVERTISED_HOST_NAME: "radar-hdfs-connector"
       CONNECT_ZOOKEEPER_CONNECT: zookeeper-1:2181
-      KAFKA_REST_PROXY: http://rest-proxy-1:8082
       TOPIC_LIST: ${RADAR_TOPIC_LIST}
       CONNECTOR_PROPERTY_FILE_PREFIX: "sink-hdfs"
 

--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -275,7 +275,7 @@ services:
   # RADAR mongo connector                                                     #
   #---------------------------------------------------------------------------#
   radar-mongodb-connector:
-    image: radarcns/radar-mongodb-connector-auto:0.2
+    image: radarcns/radar-mongodb-connector-auto:0.2.1
     restart: on-failure
     volumes:
       - ./etc/sink-mongo.properties:/etc/kafka-connect/sink.properties
@@ -318,7 +318,7 @@ services:
   # RADAR HDFS connector                                                     #
   #---------------------------------------------------------------------------#
   radar-hdfs-connector:
-    image: radarcns/radar-hdfs-connector-auto:0.2
+    image: radarcns/radar-hdfs-connector-auto:0.2.1
     restart: on-failure
     volumes:
       - ./etc/sink-hdfs.properties:/etc/kafka-connect/sink-hdfs.properties

--- a/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/topic_init.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/topic_init.sh
@@ -9,6 +9,11 @@ if [ -f /.radar_topic_set ]; then
 fi
 
 # Wait until all brokers are up & running
+if [ -z ${KAFKA_ZOOKEEPER_CONNECT} ]; then
+        echo "KAFKA_ZOOKEEPER_CONNECT is not defined"
+        exit 2
+fi
+
 interval=1
 while [ "$LENGTH" != "$KAFKA_BROKERS" ]; do
     ZOOKEEPER_CHECK=$(zookeeper-shell $KAFKA_ZOOKEEPER_CONNECT <<< "ls /brokers/ids")
@@ -32,11 +37,6 @@ done
 if [ -z ${RADAR_TOPICS} ]; then
 	echo "RADAR_TOPICS is not defined"
 	exit 2
-fi
-
-if [ -z ${KAFKA_ZOOKEEPER_CONNECT} ]; then
-        echo "KAFKA_ZOOKEEPER_CONNECT is not defined"
-        exit 2
 fi
 
 if [ -z ${RADAR_PARTITIONS} ]; then

--- a/images/radar-mongodb-connector/kafka_status.sh
+++ b/images/radar-mongodb-connector/kafka_status.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Check if variables exist
-if [ -z "$KAFKA_REST_PROXY" ]; then
-        echo "KAFKA_REST_PROXY is not defined"
+if [ -z "$CONNECT_ZOOKEEPER_CONNECT" ]; then
+        echo "CONNECT_ZOOKEEPER_CONNECT is not defined"
         exit 2
 fi
 
@@ -11,34 +11,30 @@ if [ -z "$TOPIC_LIST" ]; then
         exit 2
 fi
 
+# Save current IFS
+SAVEIFS=$IFS
+
 # Fetch env topic list
 IFS=', ' read -r -a needed <<< $TOPIC_LIST
 
 # Fetch env topic list
+IFS=$'\n'
 count=0
 interval=1
-max_retryes=5
+max_retryes=15
 while [ "$count" != "${#needed[@]}" ] ; do
 
     if [ "$max_retryes" -eq "0" ] ; then
-        echo "Error connecting to Rest-Proxy ... "
-        echo "Rebooting  ... "
+        IFS=$SAVEIFS
+        echo "Force rebooting  ... "
         exit 2
     fi
 
-    echo "Waiting $interval second before retrying ..."
-    sleep $interval
-    if (( interval < 30 )); then
-        ((interval=interval*2))
-    fi
-
     count=0
-    TOPICS=$(curl -sSX GET -H "Content-Type: application/json" "$KAFKA_REST_PROXY/topics")
-    curl_result=$?
-    TOPICS="$(echo -e "${TOPICS}" | tr -d '"'  | tr -d '['  | tr -d ']' | tr -d '[:space:]' )"
+    topics=$(kafka-topics --list --zookeeper $CONNECT_ZOOKEEPER_CONNECT)
+    topics=($topics)
 
-    IFS=',' read -r -a array <<< $TOPICS
-    for topic in "${array[@]}"
+    for topic in "${topics[@]}"
     do
         for need in "${needed[@]}"
         do
@@ -48,8 +44,13 @@ while [ "$count" != "${#needed[@]}" ] ; do
         done
     done
 
-    if [ "$curl_result" -ne "0" ] ; then
-         ((max_retryes--))
+    if [ "$count" != "${#needed[@]}" ] ; then
+        echo "Waiting $interval second before retrying ..."
+        sleep $interval
+        if (( interval < 30 )); then
+                ((interval=interval*2))
+        fi
+        ((max_retryes--))
     fi
 done
 


### PR DESCRIPTION
Connectors no longer rely on `Rest-Proxy` for checking topics availability. The check is now done using `kaka-topics`.

Note: the same check should be done on the RADAR-Backend container too. This change requires to build the Backend container from a different docker image.