### PR TITLE
Add dummy scope for OAuth clients that use a user login

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/etc/managementportal/changelogs/config/liquibase/oauth_client_details.csv.template
+++ b/dcompose-stack/radar-cp-hadoop-stack/etc/managementportal/changelogs/config/liquibase/oauth_client_details.csv.template
@@ -1,6 +1,6 @@
 client_id;resource_ids;client_secret;scope;authorized_grant_types;web_server_redirect_uri;authorities;access_token_validity;refresh_token_validity;additional_information;autoapprove
-ManagementPortalapp;res_ManagementPortal;my-secret-token-to-change-in-production;read,write;password,refresh_token,authorization_code,implicit;;ROLE_PROJECT_ADMIN,ROLE_USER,ROLE_SYS_ADMIN;1800;3600;{};true
-pRMT;res_ManagementPortal;secret;;refresh_token,authorization_code;;;43200;5184000;{"dynamic_registration": true};true
-aRMT;res_ManagementPortal;secret;;refresh_token,authorization_code;;;43200;5184000;{"dynamic_registration": true};true
+ManagementPortalapp;res_ManagementPortal;my-secret-token-to-change-in-production;DUMMY_SCOPE;password,refresh_token,authorization_code,implicit;;ROLE_PROJECT_ADMIN,ROLE_USER,ROLE_SYS_ADMIN;1800;3600;{};true
+pRMT;res_ManagementPortal;secret;DUMMY_SCOPE;refresh_token,authorization_code;;;43200;5184000;{"dynamic_registration": true};true
+aRMT;res_ManagementPortal;secret;DUMMY_SCOPE;refresh_token,authorization_code;;;43200;5184000;{"dynamic_registration": true};true
 radar_restapi;res_ManagementPortal,res_gateway;my-secret-token-to-change-in-production;SUBJECT.READ,PROJECT.READ,SOURCE.READ,DEVICETYPE.READ;client_credentials;;;1800;3600;{};true
 radar_redcap_integrator;res_ManagementPortal;my-secrect_token;PROJECT.READ,SUBJECT.CREATE,SUBJECT.READ,SUBJECT.UPDATE;client_credentials;;;1800;2000;{};true


### PR DESCRIPTION
These scopes can not be empty, it prevents a token from being created. We can simply add a dummy scope since these apps will inherit the permissions from the user that logs in.