### PR TITLE
Change ManagementPortalapp client scope

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/etc/managementportal/config/liquibase/oauth_client_details.csv.template
+++ b/dcompose-stack/radar-cp-hadoop-stack/etc/managementportal/config/liquibase/oauth_client_details.csv.template
@@ -1,5 +1,5 @@
 client_id;resource_ids;client_secret;scope;authorized_grant_types;web_server_redirect_uri;authorities;access_token_validity;refresh_token_validity;additional_information;autoapprove
-ManagementPortalapp;res_ManagementPortal;my-secret-token-to-change-in-production;DUMMY_SCOPE;password,refresh_token,authorization_code,implicit;;ROLE_PROJECT_ADMIN,ROLE_USER,ROLE_SYS_ADMIN;1800;3600;{};true
+ManagementPortalapp;res_ManagementPortal;my-secret-token-to-change-in-production;read,write;password,refresh_token,authorization_code,implicit;;ROLE_PROJECT_ADMIN,ROLE_USER,ROLE_SYS_ADMIN;1800;3600;{};true
 pRMT;res_ManagementPortal;secret;DUMMY_SCOPE;refresh_token,authorization_code;;;43200;5184000;{"dynamic_registration": true};true
 aRMT;res_ManagementPortal;secret;DUMMY_SCOPE;refresh_token,authorization_code;;;43200;5184000;{"dynamic_registration": true};true
 Thinc_It;res_ManagementPortal;secret;DUMMY_SCOPE;refresh_token,authorization_code;;;43200;5184000;{"dynamic_registration": true};true


### PR DESCRIPTION
Change scope of `ManagementPortalapp` client because it does not work with `DUMMY_SCOPE`. Currently it requires a scope of `read,write` to work.