### PR TITLE
Fix init

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/hdfs_restructure.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/hdfs_restructure.sh
@@ -8,7 +8,7 @@ fi
 . ./util.sh
 
 # HDFS restructure version
-JAR_VERSION=0.2.1
+JAR_VERSION=0.3.1
 # HDFS restructure JAR
 JAR="restructurehdfs-all-${JAR_VERSION}.jar"
 

--- a/dcompose-stack/radar-cp-hadoop-stack/install-radar-stack.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/install-radar-stack.sh
@@ -10,6 +10,8 @@ else
   sudo-linux mkdir -m 0700 ./output
 fi
 
+check_config_present .env etc/env.template
+
 . ./.env
 
 # Check provided directories and configurations

--- a/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/Dockerfile
+++ b/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/Dockerfile
@@ -8,17 +8,30 @@ ENV KAFKA_NUM_REPLICATION=2
 ENV KAFKA_NUM_BROKERS=3
 ENV KAFKA_ZOOKEEPER_CONNECT=zookeeper-1:2181
 
-RUN apk add --no-cache rsync tar bash wget
+RUN apk add --no-cache \
+  bash \
+  curl \
+  rsync \
+  tar
 
-RUN mkdir -p /schema/merged
+RUN mkdir -p /schema/merged /schema/java/src /schema/java/classes /usr/share/java
 
 WORKDIR /schema
 
-ADD https://github.com/RADAR-CNS/RADAR-Schemas/archive/v0.2.tar.gz /schema/RADAR-Schemas-0.2.tar.gz
-RUN tar xzf RADAR-Schemas-0.2.tar.gz && mv RADAR-Schemas-0.2 original && rm RADAR-Schemas-0.2.tar.gz
+ENV JQ_VERSION=1.5
+RUN curl -L#o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 \
+    && chmod +x /usr/bin/jq
+RUN curl -#o /usr/share/java/avro-tools.jar \
+ "$(curl -s http://www.apache.org/dyn/closer.cgi/avro/\?as_json \
+  | jq --raw-output ".preferred")avro/avro-1.8.2/java/avro-tools-1.8.2.jar"
 
-ADD https://github.com/RADAR-CNS/RADAR-Schemas/releases/download/v0.2/radar-schemas-tools-0.2.tar.gz /schema/radar-schemas-tools-0.2.tar.gz
-RUN tar xzf radar-schemas-tools-0.2.tar.gz --strip-components=1 -C /usr && rm radar-schemas-tools-0.2.tar.gz
+ENV RADAR_SCHEMAS_VERSION=0.2
+RUN curl -#L https://github.com/RADAR-CNS/RADAR-Schemas/releases/download/v${RADAR_SCHEMAS_VERSION}/radar-schemas-tools-${RADAR_SCHEMAS_VERSION}.tar.gz \
+  | tar xz -C /usr --strip-components 1
+
+RUN mkdir original \
+  && curl -#L https://github.com/RADAR-CNS/RADAR-Schemas/archive/v${RADAR_SCHEMAS_VERSION}.tar.gz \
+  | tar xz -C original --strip-components 1
 
 VOLUME /schema/conf
 

--- a/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/init.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/init.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
+set -e
+
 rsync -a /schema/original/commons /schema/original/specifications /schema/merged
 rsync -a /schema/conf/ /schema/merged
+
+# Compiling updated schemas
+echo "Compiling schemas..."
+# Separate enums so that they can be referenced in later files
+IFS=$'\n' read -r -a enums <<< $(find merged/commons -name "*.avsc" -exec grep -q '^  "type": "enum"' "{}" \; -print)
+IFS=$'\n' read -r -a notenums <<< $(find merged/commons -name "*.avsc" -exec grep -qv '^  "type": "enum"' "{}" \; -print)
+java -jar /usr/share/java/avro-tools.jar compile -string schema ${enums[@]} ${notenums[@]} java/src 2>/dev/null
+find java/src -name "*.java" -print0 | xargs -0 javac -cp /usr/lib/*:java/classes -d java/classes -sourcepath java/src 
+# Update the radar schemas so the tools find the new classes in classpath
+jar uf /usr/lib/radar-schemas-commons-${RADAR_SCHEMAS_VERSION}.jar -C java/classes .
 
 exec "$@"

--- a/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/topic_init.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/topic_init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Create topics
 echo "Creating RADAR-CNS topics..."
@@ -17,7 +17,7 @@ tries=10
 timeout=1
 max_timeout=32
 while true; do
-  if wget --spider -q "${KAFKA_SCHEMA_REGISTRY}" 2>/dev/null; then
+  if curl -Ifs "${KAFKA_SCHEMA_REGISTRY}" > /dev/null; then
     break;
   fi
   tries=$((tries - 1))
@@ -27,7 +27,9 @@ while true; do
   fi
   echo "Failed to reach schema registry. Retrying in ${timeout} seconds."
   sleep $timeout
-  timeout=$((timeout * 2 < max_timeout ? timeout * 2 : max_timeout))
+  if [ $timeout -lt $max_timeout ]; then
+    timeout=$((timeout * 2))
+  fi
 done
 
 if ! radar-schemas-tools register "${KAFKA_SCHEMA_REGISTRY}" merged; then

--- a/dcompose-stack/radar-cp-hadoop-stack/util.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/util.sh
@@ -97,9 +97,8 @@ check_config_present() {
     fi
     exit 1
   elif [ "$1" -ot "${template}" ]; then
-    echo "Configuration file ${1} is older than its template"
-    echo "${template}. Please edit ${1}"
-    echo "to ensure it matches the template, remove it or run touch on it."
+    echo "Configuration file ${1} is older than its template ${template}."
+    echo "Please edit ${1} to ensure it matches the template or run touch on it."
     exit 1
   fi
 }


### PR DESCRIPTION
Update of the `kafka-init` image.

- Allow schemas to be added to `etc/schema/commons`; they will be compiled during initialisation. Fixes #79.
- Use `RUN curl` instead of `ADD url` to decrease the image size and speed up caches for fixed URL contents (releases). See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy