### PR TITLE
Use latest RADAR-Schema version

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -457,7 +457,7 @@ services:
   # RADAR backend streams                                                     #
   #---------------------------------------------------------------------------#
   radar-backend-stream:
-    image: radarcns/radar-backend-kafka-auto:0.1
+    image: radarcns/radar-backend-kafka-auto:0.1.2
     command:
       - stream
     networks:
@@ -484,7 +484,7 @@ services:
   # RADAR backend monitor                                                     #
   #---------------------------------------------------------------------------#
   radar-backend-monitor:
-    image: radarcns/radar-backend-kafka-auto:0.1
+    image: radarcns/radar-backend-kafka-auto:0.1.2
     command: monitor
     networks:
       - zookeeper

--- a/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/Dockerfile
+++ b/dcompose-stack/radar-cp-hadoop-stack/kafka-radarinit/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -#o /usr/share/java/avro-tools.jar \
  "$(curl -s http://www.apache.org/dyn/closer.cgi/avro/\?as_json \
   | jq --raw-output ".preferred")avro/avro-1.8.2/java/avro-tools-1.8.2.jar"
 
-ENV RADAR_SCHEMAS_VERSION=0.2.2
+ENV RADAR_SCHEMAS_VERSION=0.2.3
 RUN curl -#L https://github.com/RADAR-CNS/RADAR-Schemas/releases/download/v${RADAR_SCHEMAS_VERSION}/radar-schemas-tools-${RADAR_SCHEMAS_VERSION}.tar.gz \
   | tar xz -C /usr --strip-components 1
 

--- a/images/radar-backend-kafka/Dockerfile
+++ b/images/radar-backend-kafka/Dockerfile
@@ -20,10 +20,10 @@ LABEL description="RADAR-CNS Backend streams and monitor"
 # Install RADAR-Backend
 RUN echo "==> Installing Components" \
     # Download Git RADAR-Backend release
-    && echo "==> Downloading RADAR-CNS/RADAR-Backend 0.1 release from GitHub" \
+    && echo "==> Downloading RADAR-CNS/RADAR-Backend 0.1.2 release from GitHub" \
     && cd /usr/local && mkdir RADAR-Backend
 
-ADD https://github.com/RADAR-CNS/RADAR-Backend/releases/download/0.1/radar-backend-0.1-all.jar /usr/share/java/
+ADD https://github.com/RADAR-CNS/RADAR-Backend/releases/download/0.1.2/radar-backend-0.1.2-all.jar /usr/share/java/
 
 # Load topics validator
 COPY ["./init.sh", "./kafka_status.sh", "/home/"]


### PR DESCRIPTION
Use the latest version of RADAR-Schemas in kafka-init so that all the new schemas are also registered
Also use latest version of RADAR-Backend with Phone streams